### PR TITLE
Deprecated compact_blank gem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ on:
       - opened
       - synchronize
       - reopened
-  schedule:
-    - cron: "0 10 * * 5" # JST 19:00 (Fri)
 
 env:
   CI: "true"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Adds `compact_blank` and `compact_blank!` to `Array` and `Hash`
 [![Coverage Status](https://coveralls.io/repos/github/sue445/compact_blank/badge.svg)](https://coveralls.io/github/sue445/compact_blank)
 [![Code Climate](https://codeclimate.com/github/sue445/compact_blank.png)](https://codeclimate.com/github/sue445/compact_blank)
 
+## :warning: `compact_blank` gem is deprecated since `activesupport` 6.1+
+Use `activesupport`'s `#compact_blank` instead of `compact_blank`
+
+see. https://github.com/sue445/compact_blank/issues/11
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/compact_blank.gemspec
+++ b/compact_blank.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activesupport", "< 6.1.0.rc1"
 
   spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency "coveralls"


### PR DESCRIPTION
Rails 6.1.0.rc1 is released.
https://weblog.rubyonrails.org/2020/11/2/Rails-6-1-rc1-release/

So this gem has finished its role

```ruby
irb(main):001:0> require "active_support/all"
=> true
irb(main):002:0> ActiveSupport.version
=> #<Gem::Version "6.1.0.rc1">
irb(main):003:0> array = ["a", nil, "b", ""]
=> ["a", nil, "b", ""]
irb(main):004:0> array.compact_blank
=> ["a", "b"]
irb(main):005:0> array.compact_blank!
=> ["a", "b"]
irb(main):006:0> hash = { a: "1", b: nil, c: "3", d: "" }
=> {:a=>"1", :b=>nil, :c=>"3", :d=>""}
irb(main):007:0> hash.compact_blank
=> {:a=>"1", :c=>"3"}
irb(main):008:0> hash.compact_blank!
=> {:a=>"1", :c=>"3"}
```

Close #11
